### PR TITLE
Fix of trying to close Cursor twice

### DIFF
--- a/src/main/java/com/j256/ormlite/android/AndroidCompiledStatement.java
+++ b/src/main/java/com/j256/ormlite/android/AndroidCompiledStatement.java
@@ -87,7 +87,7 @@ public class AndroidCompiledStatement implements CompiledStatement {
 	}
 
 	public void close() throws IOException {
-		if (cursor != null) {
+		if (cursor != null && !cursor.isClosed()) {
 			try {
 				cursor.close();
 			} catch (android.database.SQLException e) {


### PR DESCRIPTION
The warning Android prints in logcat is: Close cursor android.database.sqlite.SQLiteCursor on null twice or more

SA: http://stackoverflow.com/questions/25245249/ormlite-sqlitecursor-close-cursor-on-null-twice-or-more