### PR TITLE
Use the system's line separator in expected results

### DIFF
--- a/src/test/java/com/j256/ormlite/android/apptools/OrmLiteConfigUtilTest.java
+++ b/src/test/java/com/j256/ormlite/android/apptools/OrmLiteConfigUtilTest.java
@@ -13,12 +13,16 @@ import com.j256.ormlite.field.ForeignCollectionField;
 
 public class OrmLiteConfigUtilTest {
 
+	private static final String lineSeparator = System.getProperty("line.separator");
+
 	@Test
 	public void testBasic() throws Exception {
 		ByteArrayOutputStream output = new ByteArrayOutputStream();
 		OrmLiteConfigUtil.writeConfigFile(output, new Class[] { Foo.class });
 		String result = output.toString();
-		assertTrue(result, result.contains("\nfieldName=id\nid=true\n"));
+		assertTrue(result, result.contains(lineSeparator +
+			"fieldName=id" + lineSeparator +
+			"id=true" + lineSeparator));
 	}
 
 	@Test
@@ -26,7 +30,9 @@ public class OrmLiteConfigUtilTest {
 		ByteArrayOutputStream output = new ByteArrayOutputStream();
 		OrmLiteConfigUtil.writeConfigFile(output, new File("src/test/java/com/j256/ormlite/android/apptools/"));
 		String result = output.toString();
-		assertTrue(result, result.contains("\nfieldName=id\nid=true\n"));
+		assertTrue(result, result.contains(lineSeparator +
+			"fieldName=id" + lineSeparator +
+			"id=true" + lineSeparator));
 	}
 
 	@Test
@@ -34,7 +40,9 @@ public class OrmLiteConfigUtilTest {
 		ByteArrayOutputStream output = new ByteArrayOutputStream();
 		OrmLiteConfigUtil.writeConfigFile(output, new Class[] { ForeignCollectionTest.class });
 		String result = output.toString();
-		assertTrue(result, result.contains("\nfieldName=collection\nforeignCollection=true\n"));
+		assertTrue(result, result.contains(lineSeparator +
+			"fieldName=collection" + lineSeparator +
+			"foreignCollection=true" + lineSeparator));
 	}
 
 	@Test
@@ -42,7 +50,9 @@ public class OrmLiteConfigUtilTest {
 		ByteArrayOutputStream output = new ByteArrayOutputStream();
 		OrmLiteConfigUtil.writeConfigFile(output, new Class[] { Foo.class });
 		String result = output.toString();
-		assertTrue(result, result.contains("\nfieldName=foreign\nforeign=true\n"));
+		assertTrue(result, result.contains(lineSeparator +
+			"fieldName=foreign" + lineSeparator +
+			"foreign=true" + lineSeparator));
 	}
 
 	protected static class Foo {


### PR DESCRIPTION
Use the line.separator system property instead of "\n" when building
expected result strings to work properly on Windows