### PR TITLE
Add constructor with DatabaseErrorHandler fix #111

### DIFF
--- a/src/main/java/com/j256/ormlite/android/apptools/OrmLiteSqliteOpenHelper.java
+++ b/src/main/java/com/j256/ormlite/android/apptools/OrmLiteSqliteOpenHelper.java
@@ -66,9 +66,9 @@ public abstract class OrmLiteSqliteOpenHelper extends SQLiteOpenHelper {
 	 * @param databaseVersion
 	 *            Version of the database we are opening. This causes {@link #onUpgrade(SQLiteDatabase, int, int)} to be
 	 *            called if the stored database is a different version.
-     * @param errorHandler 
+	 * @param errorHandler 
 	 *            The <a href="https://developer.android.com/reference/android/database/DatabaseErrorHandler">DatabaseErrorHandler</a> to be used when sqlite reports database
-     *            corruption, or null to use the default error handler.
+	 *            corruption, or null to use the default error handler.
 	 */
 	public OrmLiteSqliteOpenHelper(Context context, String databaseName, CursorFactory factory, int databaseVersion, DatabaseErrorHandler errorHandler) {
 		super(context, databaseName, factory, databaseVersion, errorHandler);

--- a/src/main/java/com/j256/ormlite/android/apptools/OrmLiteSqliteOpenHelper.java
+++ b/src/main/java/com/j256/ormlite/android/apptools/OrmLiteSqliteOpenHelper.java
@@ -67,7 +67,7 @@ public abstract class OrmLiteSqliteOpenHelper extends SQLiteOpenHelper {
 	 *            Version of the database we are opening. This causes {@link #onUpgrade(SQLiteDatabase, int, int)} to be
 	 *            called if the stored database is a different version.
      * @param errorHandler 
-	 *            The {@link <a href="https://developer.android.com/reference/android/database/DatabaseErrorHandler">DatabaseErrorHandler</a>} to be used when sqlite reports database
+	 *            The <a href="https://developer.android.com/reference/android/database/DatabaseErrorHandler">DatabaseErrorHandler</a> to be used when sqlite reports database
      *            corruption, or null to use the default error handler.
 	 */
 	public OrmLiteSqliteOpenHelper(Context context, String databaseName, CursorFactory factory, int databaseVersion, DatabaseErrorHandler errorHandler) {

--- a/src/main/java/com/j256/ormlite/android/apptools/OrmLiteSqliteOpenHelper.java
+++ b/src/main/java/com/j256/ormlite/android/apptools/OrmLiteSqliteOpenHelper.java
@@ -9,6 +9,7 @@ import java.io.InputStreamReader;
 import java.sql.SQLException;
 
 import android.content.Context;
+import android.database.DatabaseErrorHandler;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteDatabase.CursorFactory;
 import android.database.sqlite.SQLiteOpenHelper;
@@ -52,6 +53,25 @@ public abstract class OrmLiteSqliteOpenHelper extends SQLiteOpenHelper {
 	 */
 	public OrmLiteSqliteOpenHelper(Context context, String databaseName, CursorFactory factory, int databaseVersion) {
 		super(context, databaseName, factory, databaseVersion);
+		logger.trace("{}: constructed connectionSource {}", this, connectionSource);
+	}
+
+	/**
+	 * @param context
+	 *            Associated content from the application. This is needed to locate the database.
+	 * @param databaseName
+	 *            Name of the database we are opening.
+	 * @param factory
+	 *            Cursor factory or null if none.
+	 * @param databaseVersion
+	 *            Version of the database we are opening. This causes {@link #onUpgrade(SQLiteDatabase, int, int)} to be
+	 *            called if the stored database is a different version.
+     * @param errorHandler 
+	 *            The {@link <a href="https://developer.android.com/reference/android/database/DatabaseErrorHandler">DatabaseErrorHandler</a>} to be used when sqlite reports database
+     *            corruption, or null to use the default error handler.
+	 */
+	public OrmLiteSqliteOpenHelper(Context context, String databaseName, CursorFactory factory, int databaseVersion, DatabaseErrorHandler errorHandler) {
+		super(context, databaseName, factory, databaseVersion, errorHandler);
 		logger.trace("{}: constructed connectionSource {}", this, connectionSource);
 	}
 


### PR DESCRIPTION
fix #111

SQLiteOpenHelper class has a constructor

public SQLiteOpenHelper(Context context, String name, CursorFactory factory, int version,
DatabaseErrorHandler errorHandler)

@param errorHandler the {@link DatabaseErrorHandler} to be used when sqlite reports database
* corruption, or null to use the default error handler.

using this we can supply our custom DatabaseErrorHandler to get the callback of void onCorruption(SQLiteDatabase dbObj); and handle the DB corruption

OrmLiteSqliteOpenHelper class does not have any constructor which accepts DatabaseErrorHandler
